### PR TITLE
[BUGFIX] Switched to FileCollectionRepository for getting collections

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -9,12 +9,12 @@ namespace FelixNagel\GenericGallery\Controller;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Core\Resource\FileCollectionRepository;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use FelixNagel\GenericGallery\Domain\Model\GalleryCollection;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\ImmediateResponseException;
 use TYPO3\CMS\Core\Resource\FileRepository;
-use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 use FelixNagel\GenericGallery\Domain\Repository\GalleryItemRepository;
@@ -234,11 +234,11 @@ abstract class AbstractController extends ActionController
      */
     protected function getCollection()
     {
-        /* @var $resourceFactory ResourceFactory */
-        $resourceFactory = $this->objectManager->get(ResourceFactory::class);
+        /* @var $fileCollectionRepository FileCollectionRepository */
+        $fileCollectionRepository = GeneralUtility::makeInstance(FileCollectionRepository::class);
 
         /* @var $collection \TYPO3\CMS\Core\Resource\Collection\AbstractFileCollection */
-        $collection = $resourceFactory->getCollectionObject((int) $this->cObjData['tx_generic_gallery_collection']);
+        $collection = $fileCollectionRepository->findByUid((int) $this->cObjData['tx_generic_gallery_collection']);
         $collection->loadContents();
 
         return $collection->getItems();


### PR DESCRIPTION
- Fixes the "PHP Warning: Undefined array key" error in PHP 8 when using
  a file collection / folder as your source