### PR TITLE
[BUGFIX] Fix inline collections with strict SQL mode (4.x)

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -107,6 +107,7 @@ call_user_func(function ($packageKey) {
             ],
             'maxitems' => 1,
             'minitems' => 0,
+            'default' => 0,
         ];
     }
 


### PR DESCRIPTION
Set the default value to 0 for inline file collections as well, so that TYPO3 does not throw the following error when saving the gallery plugin after removing the inline collection record:

> 2: SQL error: 'Incorrect integer value: '' for column
> typo3srh.tt_content.tx_generic_gallery_collection at row 1' (tt_content:6040)

Resolves: https://github.com/fnagel/generic-gallery/issues/48
Related: https://github.com/fnagel/generic-gallery/issues/35