### PR TITLE
[BUGFIX] Gracefully handle deleted image collection records (master)

### DIFF
--- a/Classes/Backend/Hooks/PageLayoutViewHook.php
+++ b/Classes/Backend/Hooks/PageLayoutViewHook.php
@@ -112,6 +112,10 @@ class PageLayoutViewHook
     protected function renderCollectionPreview()
     {
         $collection = BackendUtility::getRecord('sys_file_collection', $this->data['tx_generic_gallery_collection']);
+        if ($collection === null) {
+            //record may have been deleted
+            return;
+        }
 
         $this->tableData[] = ['Source', 'collection (' . $collection['type'] . ')'];
         $this->tableData[] = [

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -243,8 +243,13 @@ abstract class AbstractController extends ActionController
         $fileCollectionRepository = GeneralUtility::makeInstance(FileCollectionRepository::class);
 
         /* @var $collection \TYPO3\CMS\Core\Resource\Collection\AbstractFileCollection */
-        $collection = $fileCollectionRepository->findByUid((int) $this->cObjData['tx_generic_gallery_collection']);
-        $collection->loadContents();
+        try {
+            $collection = $fileCollectionRepository->findByUid((int) $this->cObjData['tx_generic_gallery_collection']);
+            $collection->loadContents();
+        } catch (\InvalidArgumentException $exception) {
+            //collection does not exist (anymore), maybe deleted.
+            return [];
+        }
 
         return $collection->getItems();
     }


### PR DESCRIPTION
When a gallery content element is linked to a deleted image file collection, previewing it in the backend will lead to an exception:

> (1/1) TypeError
> Argument 2 passed to TYPO3\CMS\Core\Imaging\IconFactory::getIconForRecord()
> must be of the type array, null given, called in
> typo3conf/ext/generic_gallery/Classes/Backend/Hooks/PageLayoutViewHook.php on line 251

Viewing the page in the frontend leads to a different error:

> (1/1) #1314085992 InvalidArgumentException
> No collection found for given UID: "25"
> in typo3/sysext/core/Classes/Resource/ResourceFactory.php line 329

This patch fixes both exceptions by
a) not rending the backend preview for the file collection record b) pretending there are no images to render in the frontend

This bug can be reproduced as follows:

1. Create generic gallery content element
2. In the element details, add image collection and provide a title
3. Save the content element and close
4. On the typo3 content element preview, click the collection icon. A context menu opens.
5. Click "delete" and confirm
6. Reload the typo3 backend page view

Related: https://github.com/fnagel/generic-gallery/pull/47