### PR TITLE
[TASK] Align ext_emconf.php PHP version constraint with composer.json

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '7.0.1-dev',
     'constraints' => [
         'depends' => [
-            'php' => '8.2.0-8.3.99',
+            'php' => '8.2.0-8.99.99',
             'typo3' => '13.3.0-13.4.99',
         ],
         'suggests' => [


### PR DESCRIPTION
Composer wants `^8.1`, so ext_emconf.php should also allow all php 8.1+ versions