### PR TITLE
[TASK] Declare compatible with PHP up to 8.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        php-versions: [7.4, 8.0, 8.1]
+        php-versions: [7.4, 8.0, 8.1, 8.2, 8.3]
         typo3-versions: [11.5]
 
     name: Run tests with PHP ${{ matrix.php-versions }} using TYPO3 ${{ matrix.typo3-versions }}

--- a/Classes/Domain/Model/GalleryCollection.php
+++ b/Classes/Domain/Model/GalleryCollection.php
@@ -25,7 +25,6 @@ class GalleryCollection extends ObjectStorage
      * @param int|string $uid UID int or virtual UID string
      *
      * @param int|string $uid
-     * @return GalleryItem
      */
     public function getByIdentifier($uid): ?GalleryItem
     {

--- a/Classes/Domain/Model/GalleryItem.php
+++ b/Classes/Domain/Model/GalleryItem.php
@@ -33,35 +33,30 @@ class GalleryItem extends AbstractEntity
     /**
      * tt_content UID.
      *
-     * @var int
      */
     protected ?int $ttContentUid = null;
 
     /**
      * title.
      *
-     * @var string
      */
     protected ?string $title = null;
 
     /**
      * link.
      *
-     * @var string
      */
     protected ?string $link = null;
 
     /**
      * imageReference.
      *
-     * @var \TYPO3\CMS\Extbase\Domain\Model\FileReference
      */
     protected ?\TYPO3\CMS\Extbase\Domain\Model\FileReference $imageReference = null;
 
     /**
      * image.
      *
-     * @var \TYPO3\CMS\Core\Resource\File
      */
     protected ?File $image = null;
 
@@ -72,9 +67,6 @@ class GalleryItem extends AbstractEntity
      */
     protected ?ObjectStorage $textItems = null;
 
-    /**
-     * @var array
-     */
     protected ?array $imageProperties = null;
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"fluid"
 	],
 	"require": {
-		"php": ">=7.4,<8.2",
+		"php": ">=7.4,<8.4",
 		"typo3/cms-core": ">=11.4.0,<=11.5.99"
 	},
 	"require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -21,7 +21,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '5.2.1-dev',
     'constraints' => [
         'depends' => [
-            'php' => '7.4.0-8.1.99',
+            'php' => '7.4.0-8.3.99',
             'typo3' => '11.4.0-11.5.99',
         ],
         'suggests' => [


### PR DESCRIPTION
.. since TYPO3v11 itself is compatible with PHP 7.4-8.3.

https://get.typo3.org/version/11#system-requirements